### PR TITLE
tests: Bump the timeout value for tests

### DIFF
--- a/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/PrestoClusterTest.groovy
+++ b/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/PrestoClusterTest.groovy
@@ -43,6 +43,7 @@ class PrestoClusterTest
   private static final String JVM_HEAPSIZE = "1024.0MB"
 
   private static final long TIMEOUT = MINUTES.toMillis(2)
+  private static final long RESPAWN_TIMEOUT = MINUTES.toMillis(4)
 
   @Inject
   private HdfsClient hdfsClient
@@ -207,7 +208,7 @@ class PrestoClusterTest
 
     retryUntil({
       nodeSshUtils.countOfPrestoProcesses(coordinatorHost) == processesCount
-    }, TIMEOUT)
+    }, RESPAWN_TIMEOUT)
   }
 
   private void assertThatApplicationIsStoppable(PrestoCluster prestoCluster)

--- a/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/slider/Slider.groovy
+++ b/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/slider/Slider.groovy
@@ -155,7 +155,7 @@ class Slider
   public void stop(String clusterName, boolean force = false)
   {
     def forceArgument = force ? '--force' : ''
-    action("stop ${clusterName} --wait 10000 ${forceArgument}")
+    action("stop ${clusterName} --wait 15000 ${forceArgument}")
   }
 
   public void action(String arg)


### PR DESCRIPTION
Tests are failing during the time when it waits for the killed processes
to be back up and running. So bump up that timeout.

SWARM-1405
