### PR TITLE
tests: Wait before asserting that slider is stoppable

### DIFF
--- a/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/PrestoClusterTest.groovy
+++ b/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/PrestoClusterTest.groovy
@@ -216,9 +216,12 @@ class PrestoClusterTest
     def allNodes = prestoCluster.allNodes
 
     prestoCluster.stop()
-
+    
+    log.debug("Checking if presto process is stopped")
     allNodes.each {
-      assertThat(nodeSshUtils.countOfPrestoProcesses(it)).isEqualTo(0)
+      retryUntil({
+        nodeSshUtils.countOfPrestoProcesses(it) == 0
+      }, TIMEOUT)
     }
   }
 }

--- a/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/slider/Slider.groovy
+++ b/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/slider/Slider.groovy
@@ -155,7 +155,7 @@ class Slider
   public void stop(String clusterName, boolean force = false)
   {
     def forceArgument = force ? '--force' : ''
-    action("stop ${clusterName} --wait 15000 ${forceArgument}")
+    action("stop ${clusterName} ${forceArgument}")
   }
 
   public void action(String arg)


### PR DESCRIPTION
The --wait argument in bin/slider stop is to delay the process of
stopping
the presto application, and not really waiting _after_ the process has
stopped. So just remove it and add a wait time in the tests (using retry
)to confirm the process
has stopped before we call the assertion statement.

SWARM-1405
