### PR TITLE
tests: Make path for presto-app package configurable

### DIFF
--- a/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/fulfillment/SliderClusterFulfiller.groovy
+++ b/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/fulfillment/SliderClusterFulfiller.groovy
@@ -38,7 +38,9 @@ public class SliderClusterFulfiller
   public static final String PACKAGE_NAME = 'PRESTO'
 
   private static final Path SLIDER_BINARY = Paths.get('target/package/slider-assembly-0.80.0-incubating-all.zip')
-  private static final Path PRESTO_PACKAGE = Paths.get('target/package/presto-yarn-package-1.0.0-SNAPSHOT.zip')
+  @Inject
+  @Named("tests.app_package.path")
+  private String presto_package_path
 
   private final Slider slider
 
@@ -53,7 +55,10 @@ public class SliderClusterFulfiller
   {
     log.info('fulfilling slider cluster')
     slider.install(SLIDER_BINARY)
-    slider.installLocalPackage(PRESTO_PACKAGE, PACKAGE_NAME)
+    
+    Path presto_app_package = Paths.get(presto_package_path)
+    log.info("Using Presto package from: " + presto_app_package)
+    slider.installLocalPackage(presto_app_package, PACKAGE_NAME)
 
     return ImmutableSet.of(slider)
   }

--- a/presto-yarn-test/src/test/resources/tempto-configuration.yaml
+++ b/presto-yarn-test/src/test/resources/tempto-configuration.yaml
@@ -34,6 +34,8 @@ databases:
 tests:
   hdfs:
     path: /product-test/presto-yarn
+  app_package:
+    path: target/package/presto-yarn-package-1.0.0-SNAPSHOT.zip
 
 ssh:
   identity: ${IDENTITY_FILE}


### PR DESCRIPTION
We need to add automation for testing Presto 0.115t version. But we do not
want to update the pom in this project to point to this version and
build against 115t(115t is not yet in maven repo anyway).

Hence we do not always want the presto-app package to be taken from
target/ build folder. So remove the hardcoded path and make it
configurable in yaml config.

SWARM-1540
