### PR TITLE
tests: Fix intermittent Hadoop issue

### DIFF
--- a/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/utils/NodeSshUtils.groovy
+++ b/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/utils/NodeSshUtils.groovy
@@ -113,7 +113,7 @@ public class NodeSshUtils
     }, MINUTES.toMillis(2))
   }
 
-  private List<String> getNodeIds()
+  public List<String> getNodeIds()
   {
     return commandOnYarn('yarn node -list')
             .split('\n')


### PR DESCRIPTION
At times Hadoop connection times out. This adds a check before each
test that the nodemanagers are actually up and running.

SWARM-1621
