### PR TITLE
test: Fix Socket timeout error in tests

### DIFF
--- a/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/slider/Slider.groovy
+++ b/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/slider/Slider.groovy
@@ -137,19 +137,27 @@ class Slider
 
   public Optional<SliderStatus> status(String appName)
   {
-    try {
-      action("status ${appName} --out status_file")
-    }
-    catch (CommandExecutionException e) {
-      if (e.exitStatus == 70) {
-        log.warn('Unable to retrieve status, application is not yet running')
-        return Optional.empty()
+    int count = 0;
+    int maxRetries = 3;
+    while(true) {
+      try {
+        action("status ${appName} --out status_file")
       }
-      else {
-        throw e
+      catch (CommandExecutionException e) {
+        if (e.exitStatus == 70) {
+          log.warn('Unable to retrieve status, application is not yet running')
+          return Optional.empty()
+        } else if (e.exitStatus == 56) {
+          log.warn('Unable to retrieve status,  node is unreachable temporarily. Retrying..')
+          if(++count == maxRetries) {
+            throw e            
+          }
+        } else {
+          throw e
+        }
       }
+      return Optional.of(new SliderStatus(sshClient.command("cat status_file")))
     }
-    return Optional.of(new SliderStatus(sshClient.command("cat status_file")))
   }
 
   public void stop(String clusterName, boolean force = false)


### PR DESCRIPTION
slider.status() intermittently fails with Hadoop Socket timeout error.
In this case, we ignore the error and retry to get the status.

SWARM-1646
