### PR TITLE
Add plugin jar functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,27 +21,28 @@ The app package built should look something like:
 Archive:  ../presto-yarn-package-1.0.0-SNAPSHOT.zip
   Length      Date    Time    Name
 ---------  ---------- -----   ----
-        0  2015-09-14 12:09   package/
-        0  2015-09-14 12:09   package/files/
-402847868  2015-09-14 12:09   package/files/presto-server-<version>.tar.gz
-      889  2015-09-14 12:09   appConfig-default.json
-      606  2015-09-14 12:09   resources-default.json
-        0  2015-09-14 12:09   package/scripts/
-        0  2015-09-14 12:09   package/templates/
-      897  2015-09-14 12:09   package/scripts/presto_coordinator.py
-      892  2015-09-14 12:09   package/scripts/presto_worker.py
-     2205  2015-09-14 12:09   package/scripts/configure.py
-      787  2015-09-14 12:09   package/scripts/__init__.py
-     2033  2015-09-14 12:09   package/scripts/params.py
-     1944  2015-09-14 12:09   package/scripts/presto_server.py
-      948  2015-09-14 12:09   package/files/README.txt
-      200  2015-09-14 12:09   package/templates/config.properties-WORKER.j2
-       69  2015-09-14 12:09   package/templates/node.properties.j2
-      268  2015-09-14 12:09   package/templates/config.properties-COORDINATOR.j2
-      186  2015-09-14 12:09   package/templates/jvm.config.j2
-     2020  2015-09-14 12:09   metainfo.xml
+        0  2015-11-30 22:57   package/
+        0  2015-11-30 22:57   package/files/
+411459833  2015-11-30 20:26   package/files/presto-server-0.123.tar.gz
+     1210  2015-11-30 22:57   appConfig-default.json
+      606  2015-11-30 22:57   resources-default.json
+        0  2015-11-30 20:26   package/scripts/
+        0  2015-11-30 21:22   package/plugins/
+        0  2015-11-30 20:26   package/templates/
+      897  2015-11-30 22:57   package/scripts/presto_coordinator.py
+      892  2015-11-30 22:57   package/scripts/presto_worker.py
+     2801  2015-11-30 22:57   package/scripts/configure.py
+      787  2015-11-30 22:57   package/scripts/__init__.py
+     2285  2015-11-30 22:57   package/scripts/params.py
+     1944  2015-11-30 22:57   package/scripts/presto_server.py
+       35  2015-11-30 22:57   package/plugins/README.txt
+      948  2015-11-30 22:57   package/files/README.txt
+      236  2015-11-30 22:57   package/templates/config.properties-WORKER.j2
+       69  2015-11-30 22:57   package/templates/node.properties.j2
+      304  2015-11-30 22:57   package/templates/config.properties-COORDINATOR.j2
+     2020  2015-11-30 22:57   metainfo.xml
 ---------                     -------
-402861812                     19 files
+411474867                     20 files
 ```
 
 ## Preparing other slider specific configuration
@@ -60,6 +61,7 @@ Archive:  ../presto-yarn-package-1.0.0-SNAPSHOT.zip
 ```
     "site.global.catalog": "{'hive': ['connector.name=hive-cdh5', 'hive.metastore.uri=thrift://${NN_HOST}:9083'], 'tpch': ['connector.name=tpch']}"
 ```
+* To add plugin jars add the site.global.plugin property in your appConfig.json. It should be of the format {'connector1' : ['jar1', 'jar2'..], 'connector2' : ['jar3', 'jar4'..]..}. This will copy jar1, jar2 to Presto plugin directory at plugin/connector1 directory and jar3, jar4 at plugin/connector2 directory. Make sure you have the plugin jars you want to add to Presto available at ```presto-yarn-package/src/main/slider/package/plugins/``` and thus the app package built presto-yarn-package-1.0.0-SNAPSHOT.zip will have the jars under ```package/plugins``` directory.
 
 * If you want to use a port other than 8080 for Presto server, configure it via site.global.presto_server_port in appConfig.json
 

--- a/presto-yarn-package/src/main/resources/appConfig-test-no-catalog.json
+++ b/presto-yarn-package/src/main/resources/appConfig-test-no-catalog.json
@@ -7,6 +7,7 @@
     "site.global.user_group": "hadoop",
     "site.global.data_dir": "/var/presto/data",
     "site.global.app_name": "${dep.pkg.basename}",
+    "site.global.app_pkg_plugin": "${AGENT_WORK_ROOT}/app/definition/package/plugins/",
     "site.global.singlenode": "true",
     "site.global.coordinator_host": "${COORDINATOR_HOST}",
     "site.global.presto_query_max_memory": "5GB",

--- a/presto-yarn-package/src/main/resources/appConfig-test.json
+++ b/presto-yarn-package/src/main/resources/appConfig-test.json
@@ -7,14 +7,17 @@
     "site.global.user_group": "hadoop",
     "site.global.data_dir": "/var/presto/data",
     "site.global.app_name": "${dep.pkg.basename}",
+    "site.global.app_pkg_plugin": "${AGENT_WORK_ROOT}/app/definition/package/plugins/",
     "site.global.singlenode": "true",
     "site.global.coordinator_host": "${COORDINATOR_HOST}",
     "site.global.presto_query_max_memory": "5GB",
     "site.global.presto_query_max_memory_per_node": "600MB",
     "site.global.presto_server_port": "8080",
-
-    "site.global.catalog": "{'hive': ['connector.name=hive-cdh5', 'hive.metastore.uri=thrift://${NN_HOST}:9083'], 'tpch': ['connector.name=tpch']}",
+    
+    "site.global.catalog": "{'hive': ['connector.name=hive-cdh5', 'hive.metastore.uri=thrift://${NN_HOST}:9083'], 'tpch': ['connector.name=tpch'], 'jmx': ['connector.name=jmx']}",
     "site.global.jvm_args": "['-server', '-Xmx1024M', '-XX:+UseG1GC', '-XX:G1HeapRegionSize=32M', '-XX:+UseGCOverheadLimit', '-XX:+ExplicitGCInvokesConcurrent', '-XX:+HeapDumpOnOutOfMemoryError', '-XX:OnOutOfMemoryError=kill -9 %p', '-DHADOOP_USER_NAME=hdfs', '-Duser.timezone=UTC']",
+
+    "site.global.plugin": "{'ml': ['presto-ml-${presto.version}.jar']}",
 
     "application.def": ".slider/package/PRESTO/${app.package.name}.zip",
     "java_home": "/usr/lib/jvm/java"

--- a/presto-yarn-package/src/main/resources/appConfig.json
+++ b/presto-yarn-package/src/main/resources/appConfig.json
@@ -7,6 +7,7 @@
     "site.global.user_group": "hadoop",
     "site.global.data_dir": "/var/presto/data",
     "site.global.app_name": "${dep.pkg.basename}",
+    "site.global.app_pkg_plugin": "${AGENT_WORK_ROOT}/app/definition/package/plugins/",
     "site.global.singlenode": "true",
     "site.global.coordinator_host": "${COORDINATOR_HOST}",
     "site.global.presto_query_max_memory": "5GB",

--- a/presto-yarn-package/src/main/slider/package/plugins/README.txt
+++ b/presto-yarn-package/src/main/slider/package/plugins/README.txt
@@ -14,7 +14,4 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-
-Place the presto-server-<version>.tar.gz installation file here, after manually configuring etc/ and the config files under presto-server-<version>/etc
-
-
+Place Presto plugin jars in this directory.

--- a/presto-yarn-package/src/main/slider/package/scripts/configure.py
+++ b/presto-yarn-package/src/main/slider/package/scripts/configure.py
@@ -18,7 +18,7 @@ limitations under the License.
 
 """
 from resource_management import *
-import ast
+import ast, os, shutil
 
 def set_configuration(component=None):
     """
@@ -45,6 +45,15 @@ def set_configuration(component=None):
         catalog_dict = ast.literal_eval(params.catalog_properties)
         for key, value in catalog_dict.iteritems():
             _store_configuration(value, format("{params.catalog_dir}/{key}.properties"))
+
+    if params.addon_plugins:
+        plugins_dict = ast.literal_eval(params.addon_plugins)
+        for key, value in plugins_dict.iteritems():
+            plugin_dir = os.path.join(params.presto_plugin_dir, key)
+            if not os.path.exists(plugin_dir):
+                os.makedirs(plugin_dir)
+            for jar in value:
+                shutil.copy2(os.path.join(params.source_plugin_dir, jar), plugin_dir)
 
 
 def _store_configuration(parameters, path):

--- a/presto-yarn-package/src/main/slider/package/scripts/params.py
+++ b/presto-yarn-package/src/main/slider/package/scripts/params.py
@@ -32,6 +32,9 @@ app_name = config['configurations']['global']['app_name']
 presto_root = format("{app_root}/{app_name}")
 conf_dir = format("{presto_root}/etc")
 catalog_dir = format("{conf_dir}/catalog")
+presto_plugin_dir = format("{presto_root}/plugin")
+source_plugin_dir = config['configurations']['global']['app_pkg_plugin']
+addon_plugins = default('/configurations/global/plugin', '')
 
 presto_user = config['configurations']['global']['app_user']
 user_group = config['configurations']['global']['user_group']

--- a/presto-yarn-test/pom.xml
+++ b/presto-yarn-test/pom.xml
@@ -32,6 +32,8 @@
     <properties>
         <skip.product.tests>true</skip.product.tests>
         <package.dir>${project.build.directory}/package</package.dir>
+        <app.package>presto-yarn-package-${project.version}</app.package>
+        <presto.server>presto-server-${presto.version}</presto.server>
     </properties>
 
     <build>
@@ -68,10 +70,10 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>copy package</id>
+                        <id>unpack presto app package</id>
                         <phase>process-test-resources</phase>
                         <goals>
-                            <goal>copy</goal>
+                            <goal>unpack</goal>
                         </goals>
                         <configuration>
                             <artifactItems>
@@ -82,7 +84,37 @@
                                     <type>zip</type>
                                 </artifactItem>
                             </artifactItems>
-                            <outputDirectory>${project.build.directory}/package</outputDirectory>
+                            <outputDirectory>${package.dir}/${app.package}</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy presto-ml to plugins</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeArtifactIds>presto-ml</includeArtifactIds>
+                            <includeTypes>jar</includeTypes>
+                            <outputDirectory>${package.dir}/${app.package}/package/plugins</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>unpack presto server tarball</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.facebook.presto</groupId>
+                                    <artifactId>presto-server</artifactId>
+                                    <version>${presto.version}</version>
+                                    <type>tar.gz</type>
+                                </artifactItem>
+                            </artifactItems>
+                            <outputDirectory>${package.dir}</outputDirectory>
                         </configuration>
                     </execution>
                     <execution>
@@ -144,8 +176,43 @@
                 <version>${groovy-eclipse-compiler.version}</version>
                 <extensions>true</extensions>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>${maven-assembly-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>build presto server tar excluding ml</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptor>${project.basedir}/src/test/assembly/presto-server.xml</descriptor>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <finalName>${presto.server}</finalName>
+                            <outputDirectory>${package.dir}/${app.package}/package/files</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>build presto app package for tests</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptor>${project.basedir}/src/test/assembly/presto-app.xml</descriptor>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <finalName>${app.package}</finalName>
+                            <outputDirectory>${package.dir}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
+
     <dependencies>
         <dependency>
             <groupId>com.teradata.tempto</groupId>
@@ -168,6 +235,11 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-ml</artifactId>
+            <version>${presto.version}</version>
         </dependency>
     </dependencies>
 

--- a/presto-yarn-test/src/test/assembly/presto-app.xml
+++ b/presto-yarn-test/src/test/assembly/presto-app.xml
@@ -1,0 +1,41 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~  or more contributor license agreements.  See the NOTICE file
+  ~  distributed with this work for additional information
+  ~  regarding copyright ownership.  The ASF licenses this file
+  ~  to you under the Apache License, Version 2.0 (the
+  ~  "License"); you may not use this file except in compliance
+  ~  with the License.  You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+
+
+<assembly
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+
+    <id>presto_app_v${project.version}</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+
+    <!-- Assemble presto app package for product tests -->
+    <fileSets>
+        <fileSet>
+            <directory>${package.dir}/${app.package}</directory>
+            <outputDirectory>/</outputDirectory>
+            <fileMode>0755</fileMode>
+            <directoryMode>0755</directoryMode>
+            <useDefaultExcludes>false</useDefaultExcludes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/presto-yarn-test/src/test/assembly/presto-server.xml
+++ b/presto-yarn-test/src/test/assembly/presto-server.xml
@@ -1,0 +1,44 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~  or more contributor license agreements.  See the NOTICE file
+  ~  distributed with this work for additional information
+  ~  regarding copyright ownership.  The ASF licenses this file
+  ~  to you under the Apache License, Version 2.0 (the
+  ~  "License"); you may not use this file except in compliance
+  ~  with the License.  You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+
+
+<assembly
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+
+    <id>presto_server_v${presto.version}</id>
+    <formats>
+        <format>tar.gz</format>
+    </formats>
+    <includeBaseDirectory>true</includeBaseDirectory>
+    
+    <!-- Assemble presto server tarball excluding ml module -->
+    <fileSets>
+        <fileSet>
+            <directory>${package.dir}/${presto.server}</directory>
+            <outputDirectory>/</outputDirectory>
+            <fileMode>0755</fileMode>
+            <directoryMode>0755</directoryMode>
+            <useDefaultExcludes>false</useDefaultExcludes>
+            <excludes>
+                <exclude>**/ml/presto-ml-${presto.version}.jar</exclude>
+            </excludes>
+        </fileSet>
+    </fileSets>
+</assembly>


### PR DESCRIPTION
Make plugin jar adding functionality to the app package. Now we can
configure the catalog and corresponding jars which needs to be added to
plugin/catalog directory. Make sure the app package has the jars copied
under package/plugins directory.

Task: SWARM-1686
Reviewed by: kokosing
