### PR TITLE
Fix bug in missing catalog properties scenario

### DIFF
--- a/presto-yarn-package/src/main/resources/appConfig-no-catalog.json
+++ b/presto-yarn-package/src/main/resources/appConfig-no-catalog.json
@@ -1,0 +1,25 @@
+{
+  "schema": "http://example.org/specification/v2.0.0",
+  "metadata": {
+  },
+  "global": {
+    "site.global.app_user": "yarn",
+    "site.global.user_group": "hadoop",
+    "site.global.data_dir": "/var/presto/data",
+    "site.global.app_name": "${dep.pkg.basename}",
+    "site.global.singlenode": "true",
+    "site.global.coordinator_host": "${COORDINATOR_HOST}",
+    "site.global.presto_jvm_heapsize": "1024M",
+    "site.global.presto_query_max_memory": "5GB",
+    "site.global.presto_query_max_memory_per_node": "600MB",
+    "site.global.presto_server_port": "8080",
+
+    "application.def": ".slider/package/PRESTO/${app.package.name}.zip",
+    "java_home": "/usr/lib/jvm/java"
+  },
+  "components": {
+    "slider-appmaster": {
+      "jvm.heapsize": "128M"
+    }
+  }
+}

--- a/presto-yarn-package/src/main/slider/package/scripts/configure.py
+++ b/presto-yarn-package/src/main/slider/package/scripts/configure.py
@@ -37,12 +37,12 @@ def set_configuration(component=None):
     _template_config("{params.conf_dir}/jvm.config", params)
     _template_config("{params.conf_dir}/node.properties", params)
 
-    catalog_properties = params.config['configurations']['global']['catalog']
-    catalog_dict = ast.literal_eval(catalog_properties)
-    for key, value in catalog_dict.iteritems():
-        for configuration in value:
-            with open(format("{params.catalog_dir}/{key}.properties"), 'a') as fw:
-                fw.write("%s\n" % configuration)
+    if params.catalog_properties:
+        catalog_dict = ast.literal_eval(params.catalog_properties)
+        for key, value in catalog_dict.iteritems():
+            for configuration in value:
+                with open(format("{params.catalog_dir}/{key}.properties"), 'a') as fw:
+                    fw.write("%s\n" % configuration)
 
 
 def _directory(path, params):

--- a/presto-yarn-package/src/main/slider/package/scripts/params.py
+++ b/presto-yarn-package/src/main/slider/package/scripts/params.py
@@ -51,4 +51,4 @@ presto_server_port = config['configurations']['global']['presto_server_port']
 
 node_id = uuid.uuid1()
 
-catalog_properties = config['configurations']['global']['catalog']
+catalog_properties = default('/configurations/global/catalog', '')

--- a/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/PrestoClusterTest.groovy
+++ b/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/PrestoClusterTest.groovy
@@ -14,7 +14,6 @@
 
 package com.teradata.presto.yarn
 
-import com.google.common.collect.ImmutableList
 import com.google.inject.Inject
 import com.teradata.presto.yarn.fulfillment.ImmutableNationTable
 import com.teradata.presto.yarn.slider.Slider
@@ -43,7 +42,9 @@ class PrestoClusterTest
         extends ProductTest
 {
 
-  private static final String TEMPLATE = 'appConfig.json'
+  private static final String APP_CONFIG_TEMPLATE = 'appConfig.json'
+  private static final String APP_CONFIG_WITHOUT_CATALOG_TEMPLATE = 'appConfig-no-catalog.json'
+
   private static final String JVM_HEAPSIZE = "1024.0MB"
 
   private static final long TIMEOUT = MINUTES.toMillis(4)
@@ -95,7 +96,7 @@ class PrestoClusterTest
   @Test
   void 'single node presto app lifecycle'()
   {
-    PrestoCluster prestoCluster = new PrestoCluster(slider, hdfsClient, 'resources-singlenode.json', TEMPLATE)
+    PrestoCluster prestoCluster = new PrestoCluster(slider, hdfsClient, 'resources-singlenode.json', APP_CONFIG_TEMPLATE)
     prestoCluster.withPrestoCluster {
       prestoCluster.assertThatPrestoIsUpAndRunning(0)
 
@@ -110,9 +111,22 @@ class PrestoClusterTest
   }
 
   @Test
+  void 'single node presto app missing catalog'()
+  {
+    PrestoCluster prestoCluster = new PrestoCluster(slider, hdfsClient, 'resources-singlenode.json', APP_CONFIG_WITHOUT_CATALOG_TEMPLATE)
+    prestoCluster.withPrestoCluster {
+      prestoCluster.assertThatPrestoIsUpAndRunning(0)
+
+      assertThatAllProcessesAreRunning(prestoCluster)
+
+      assertThatApplicationIsStoppable(prestoCluster)
+    }
+  }
+
+  @Test
   void 'limit single node failures'()
   {
-    PrestoCluster prestoCluster = new PrestoCluster(slider, hdfsClient, 'resources-singlenode-label.json', TEMPLATE)
+    PrestoCluster prestoCluster = new PrestoCluster(slider, hdfsClient, 'resources-singlenode-label.json', APP_CONFIG_TEMPLATE)
     prestoCluster.withPrestoCluster {
       prestoCluster.assertThatPrestoIsUpAndRunning(0)
 
@@ -141,7 +155,7 @@ class PrestoClusterTest
   @Test
   void 'multi node with placement lifecycle'()
   {
-    PrestoCluster prestoCluster = new PrestoCluster(slider, hdfsClient, 'resources-multinode.json', TEMPLATE)
+    PrestoCluster prestoCluster = new PrestoCluster(slider, hdfsClient, 'resources-multinode.json', APP_CONFIG_TEMPLATE)
     prestoCluster.withPrestoCluster {
       prestoCluster.assertThatPrestoIsUpAndRunning(workersCount())
 
@@ -165,7 +179,7 @@ class PrestoClusterTest
   @Requires(ImmutableNationTable.class)
   void 'multi node with placement - checking connectors'()
   {
-    PrestoCluster prestoCluster = new PrestoCluster(slider, hdfsClient, 'resources-multinode.json', TEMPLATE)
+    PrestoCluster prestoCluster = new PrestoCluster(slider, hdfsClient, 'resources-multinode.json', APP_CONFIG_TEMPLATE)
     prestoCluster.withPrestoCluster {
       prestoCluster.assertThatPrestoIsUpAndRunning(workersCount())
 
@@ -208,7 +222,7 @@ class PrestoClusterTest
   @Test
   void 'labeling subset of nodes - single cordinatoor@master'()
   {
-    PrestoCluster prestoCluster = new PrestoCluster(slider, hdfsClient, 'resources-single-coordinator@master.json', TEMPLATE)
+    PrestoCluster prestoCluster = new PrestoCluster(slider, hdfsClient, 'resources-single-coordinator@master.json', APP_CONFIG_TEMPLATE)
     prestoCluster.withPrestoCluster {
       prestoCluster.assertThatPrestoIsUpAndRunning(0)
 
@@ -221,7 +235,7 @@ class PrestoClusterTest
   @Test
   void 'flex set of workers - multinode-flex-worker'()
   {
-    PrestoCluster prestoCluster = new PrestoCluster(slider, hdfsClient, 'resources-multinode-single-worker.json', TEMPLATE)
+    PrestoCluster prestoCluster = new PrestoCluster(slider, hdfsClient, 'resources-multinode-single-worker.json', APP_CONFIG_TEMPLATE)
     prestoCluster.withPrestoCluster {
       prestoCluster.assertThatPrestoIsUpAndRunning(1)
       assertThatAllProcessesAreRunning(prestoCluster)


### PR DESCRIPTION
When there is no catalog properties provided in appConfig.json,
configure used to throw an exception when trying to create the
connector.properties files. Instead we just skip configure in case where
catalog property is missing in appConfig.json

Task: SWARM-1716
Testing: product tests
