### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,15 @@ $ hdfs dfs -chown <user>:<user> -R /user/<user>
   </property>
 ```
  
+* Configure path where slide packages will be installed
+
+``` 
+  <property>
+    <name>fs.defaultFS</name>
+    <value>hdfs://master/</value>
+  </property>
+```
+ 
 * Now run slider as <user>
 ```
 su <user>


### PR DESCRIPTION
Add information about updating the path where slider packages will be installed. 
It is needed as by default they could be installed in local file system, causing slider
app master to fail because it is unable to find package files.
