### PR TITLE
Wait 30 seconds for process to be killed after kill -9

### DIFF
--- a/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/PrestoClusterTest.groovy
+++ b/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/PrestoClusterTest.groovy
@@ -26,7 +26,6 @@ import com.teradata.tempto.hadoop.hdfs.HdfsClient
 import com.teradata.tempto.query.QueryExecutor
 import com.teradata.tempto.ssh.SshClient
 import groovy.util.logging.Slf4j
-import org.assertj.core.data.Offset
 import org.testng.annotations.Test
 
 import javax.inject.Named
@@ -169,7 +168,6 @@ class PrestoClusterTest
       5.times {
         assertThat(nodeSshUtils.countOfPrestoProcesses(coordinatorHost)).isEqualTo(1)
         nodeSshUtils.killPrestoProcesses(coordinatorHost)
-        assertThat(nodeSshUtils.countOfPrestoProcesses(coordinatorHost)).isZero()
 
         retryUntil({
           nodeSshUtils.countOfPrestoProcesses(coordinatorHost) == 1
@@ -337,12 +335,11 @@ class PrestoClusterTest
     int processesCount = nodeSshUtils.countOfPrestoProcesses(coordinatorHost)
     nodeSshUtils.killPrestoProcesses(coordinatorHost)
 
-    assertThat(nodeSshUtils.countOfPrestoProcesses(coordinatorHost)).isZero()
-
     retryUntil({
       nodeSshUtils.countOfPrestoProcesses(coordinatorHost) == processesCount
     }, TIMEOUT)
   }
+
 
   private void assertThatApplicationIsStoppable(PrestoCluster prestoCluster)
   {

--- a/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/utils/NodeSshUtils.groovy
+++ b/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/utils/NodeSshUtils.groovy
@@ -14,12 +14,15 @@
 
 package com.teradata.presto.yarn.utils
 
+import com.google.common.base.CharMatcher
+import com.google.common.base.Splitter
 import com.teradata.tempto.context.State
 import com.teradata.tempto.ssh.SshClient
 import com.teradata.tempto.ssh.SshClientFactory
 import groovy.util.logging.Slf4j
 import org.apache.commons.lang3.StringUtils
 
+import static com.google.common.base.CharMatcher.anyOf
 import static com.google.common.base.Preconditions.checkState
 import static com.google.common.collect.Sets.newHashSet
 import static com.teradata.presto.yarn.utils.TimeUtils.retryUntil
@@ -126,7 +129,7 @@ public class NodeSshUtils
     return commandOnYarn('yarn node -list')
             .split('\n')
             .findAll { it.contains('RUNNING') }
-            .collect { it.split(' ')[0].trim() }
+            .collect { Splitter.on(anyOf(' \t')).omitEmptyStrings().trimResults().split(it)[0] }
   }
 
   public String commandOnYarn(String command)

--- a/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/utils/NodeSshUtils.groovy
+++ b/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/utils/NodeSshUtils.groovy
@@ -14,13 +14,14 @@
 
 package com.teradata.presto.yarn.utils
 
-import com.google.common.base.CharMatcher
 import com.google.common.base.Splitter
 import com.teradata.tempto.context.State
 import com.teradata.tempto.ssh.SshClient
 import com.teradata.tempto.ssh.SshClientFactory
 import groovy.util.logging.Slf4j
 import org.apache.commons.lang3.StringUtils
+
+import java.util.concurrent.TimeUnit
 
 import static com.google.common.base.CharMatcher.anyOf
 import static com.google.common.base.Preconditions.checkState
@@ -58,6 +59,9 @@ public class NodeSshUtils
   public void killPrestoProcesses(String host)
   {
     runOnNode(host, ["pkill -9 -f 'java.*PrestoServer.*'"])
+    retryUntil({
+      countOfPrestoProcesses(host) == 0
+    }, TimeUnit.SECONDS.toMillis(10))
   }
 
   public String getPrestoJvmMemory(String host)


### PR DESCRIPTION
Wait 30 seconds for process to be killed after kill -9

It happens on automation that after kill -9 process still exists, it
may be due high load on the node that time needed for process to respond
to signal is longer.

Testing: on vsphere cluster
Reviewers: anu.sudursan
