### PR TITLE
Allow adding custom properties to presto config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Follow the steps here and configure the presto-yarn configuration files to match
 
 * To add plugin jars add the ``site.global.plugin`` property in your ``appConfig.json``. It should be of the format {'connector1' : ['jar1', 'jar2'..], 'connector2' : ['jar3', 'jar4'..]..}. This will copy jar1, jar2 to Presto plugin directory at plugin/connector1 directory and jar3, jar4 at plugin/connector2 directory. Make sure you have the plugin jars you want to add to Presto available at ```presto-yarn-package/src/main/slider/package/plugins/``` prior to building the presto-yarn app package and thus the app package built presto-yarn-package-*.zip will have the jars under ```package/plugins``` directory.
 
+* Presto launched via Slider will use ``config.properties`` and ``node.properties`` created from templates ``presto-yarn-package/package/templates/config.properties*.j2`` and ``presto-yarn-package/package/target/node.properties.j2`` respectively. If you want to add any additional properties to these configuration files, add ``site.global.additional_config_properties`` and ``site.global.additional_node_properties`` to your ``appConfig.json``. The value of these has to be a string with each property that has to go to the ``.properties`` file separated by a ``\n``. Eg:
+
+    "site.global.additional_catalog_properties": "task.max-worker-threads=5\ndistributed-joins-enabled=true"
+
 * If you want to use a port other than 8080 for Presto server, configure it via ``site.global.presto_server_port`` in ``appConfig.json``
 
 * Variables in ``appConfig.json`` like ``${COORDINATOR_HOST}``, ``${AGENT_WORK_ROOT}`` etc. do not need any substitution and will be appropriately configured during runtime.
@@ -229,7 +233,9 @@ hdfs dfs -chown yarn:yarn /user/yarn
 
 * Make sure the data directory in the UI (added in ``appConfig-default.json`` eg: ``/var/lib/presto/``) is pre-created on all nodes and the directory must owned by user ``yarn``, otherwise slider will fail to start Presto with permission errors.
 
-* Click Finish. This will basically do the equivalent of ```package  --install``` and ```create``` you do via the ``bin/slider`` script. Once successfully deployed, you will see the Yarn application started for Presto.
+* If you want to add any additional Custom properties, use Custom property section. Additional properties supported as of now are ``global.plugin``, ``global.additional_config_properties`` and ``global.additional_node_propeties``. See ``Presto App Package configuration`` section above for requirements and format of these properties.
+
+* Click Finish. This will basically do the equivalent of ```package  --install``` and ```create``` you do via the bin/slider script. Once successfully deployed, you will see the Yarn application started for Presto.
 
 * You can manage the application lifecycle (e.g. start, stop, flex, destroy) from the View UI.
 
@@ -237,7 +243,7 @@ hdfs dfs -chown yarn:yarn /user/yarn
 
 Once the application is launched if you want to update the configuration of Presto (eg: add a new connector), first go to Actions on the Slider View instance screen and stop the running application.
 
-Once the running YARN application is stopped, under Actions you will have an option to 'Destroy' the existing Presto instance running via Slider. Destroy the existing one and re-create a new instance with whatever updates you want to make to the configuration.
+Once the running YARN application is stopped, under Actions you will have an option to 'Destroy' the existing Presto instance running via Slider. Destroy the existing one and re-create a new app (Create App button) with whatever updates you want to make to the configuration.
 
 ## Advanced Configuration
 

--- a/presto-yarn-package/src/main/resources/appConfig-test.json
+++ b/presto-yarn-package/src/main/resources/appConfig-test.json
@@ -17,6 +17,8 @@
     "site.global.catalog": "{'hive': ['connector.name=hive-cdh5', 'hive.metastore.uri=thrift://${NN_HOST}:9083'], 'tpch': ['connector.name=tpch'], 'jmx': ['connector.name=jmx']}",
     "site.global.jvm_args": "['-server', '-Xmx1024M', '-XX:+UseG1GC', '-XX:G1HeapRegionSize=32M', '-XX:+UseGCOverheadLimit', '-XX:+ExplicitGCInvokesConcurrent', '-XX:+HeapDumpOnOutOfMemoryError', '-XX:OnOutOfMemoryError=kill -9 %p', '-DHADOOP_USER_NAME=hdfs', '-Duser.timezone=UTC']",
 
+    "site.global.additional_node_properties": "plugin.config-dir=${AGENT_WORK_ROOT}/app/install/${dep.pkg.basename}/etc/catalog\nplugin.dir=${AGENT_WORK_ROOT}/app/install/${dep.pkg.basename}/plugin",
+
     "site.global.plugin": "{'ml': ['presto-ml-${presto.version}.jar']}",
 
     "application.def": ".slider/package/PRESTO/${app.package.name}.zip",

--- a/presto-yarn-package/src/main/slider/package/scripts/params.py
+++ b/presto-yarn-package/src/main/slider/package/scripts/params.py
@@ -55,3 +55,5 @@ jvm_args = default('/configurations/global/jvm_args', '')
 node_id = uuid.uuid1()
 
 catalog_properties = default('/configurations/global/catalog', '')
+additional_config_properties=default('/configurations/global/additional_config_properties', '')
+additional_node_properties=default('/configurations/global/additional_node_properties', '')

--- a/presto-yarn-package/src/main/slider/package/templates/config.properties-COORDINATOR.j2
+++ b/presto-yarn-package/src/main/slider/package/templates/config.properties-COORDINATOR.j2
@@ -5,3 +5,4 @@ http-server.http.port={{presto_server_port}}
 query.max-memory={{presto_query_max_memory}}
 query.max-memory-per-node={{presto_query_max_memory_per_node}}
 discovery.uri=http://localhost:{{presto_server_port}}
+{{additional_config_properties}}

--- a/presto-yarn-package/src/main/slider/package/templates/config.properties-WORKER.j2
+++ b/presto-yarn-package/src/main/slider/package/templates/config.properties-WORKER.j2
@@ -3,3 +3,4 @@ http-server.http.port={{presto_server_port}}
 query.max-memory={{presto_query_max_memory}}
 query.max-memory-per-node={{presto_query_max_memory_per_node}}
 discovery.uri=http://{{coordinator_host}}:{{presto_server_port}}
+{{additional_config_properties}}

--- a/presto-yarn-package/src/main/slider/package/templates/node.properties.j2
+++ b/presto-yarn-package/src/main/slider/package/templates/node.properties.j2
@@ -1,3 +1,4 @@
 node.environment=test
 node.id={{node_id}}
 node.data-dir={{data_dir}}
+{{additional_node_properties}}

--- a/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/PrestoClusterTest.groovy
+++ b/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/PrestoClusterTest.groovy
@@ -49,7 +49,9 @@ class PrestoClusterTest
 
   private static final String JVM_HEAPSIZE = "1024.0MB"
   private static final String JVM_ARGS = "-DHADOOP_USER_NAME=hdfs -Duser.timezone=UTC"
-
+  private static final String ADDITIONAL_NODE_PROPERTY1 = "-Dplugin.config-dir="
+  private static final String ADDITIONAL_NODE_PROPERTY2 = "-Dplugin.dir="
+  
   private static final long TIMEOUT = MINUTES.toMillis(4)
 
   private static final long FLEX_RETRY_TIMEOUT = MINUTES.toMillis(10)
@@ -117,6 +119,8 @@ class PrestoClusterTest
       assertThatMemorySettingsAreCorrect(prestoCluster)
 
       assertThatJvmArgsAreCorrect(prestoCluster)
+
+      assertThatAdditionalPropertiesAreAdded(prestoCluster)
 
       assertThatKilledProcessesRespawn(prestoCluster)
 
@@ -309,6 +313,15 @@ class PrestoClusterTest
     assertThat(prestoJvmMemory).isEqualTo(JVM_HEAPSIZE)
   }
 
+  private void assertThatAdditionalPropertiesAreAdded(PrestoCluster prestoCluster)
+  {
+    String coordinatorHost = prestoCluster.coordinatorHost
+    def prestoProcess = nodeSshUtils.getPrestoJvmProcess(coordinatorHost)
+
+    assertThat(prestoProcess).contains(ADDITIONAL_NODE_PROPERTY1)
+    assertThat(prestoProcess).contains(ADDITIONAL_NODE_PROPERTY2)
+  }
+  
   private void assertThatJvmArgsAreCorrect(PrestoCluster prestoCluster)
   {
     String coordinatorHost = prestoCluster.coordinatorHost


### PR DESCRIPTION
If the user wants to add custom properties to node.properties and
config.properties, he should be able to do it via changing the
appConfig.json

SWARM-1792
Testing: ran product tests
