### PR TITLE
Make additional properties an array type instead of string

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,10 @@ Follow the steps here and configure the presto-yarn configuration files to match
     "site.global.jvm_args": "['-server', '-Xmx1024M', '-XX:+UseG1GC', '-XX:G1HeapRegionSize=32M', '-XX:+UseGCOverheadLimit', '-XX:+ExplicitGCInvokesConcurrent', '-XX:+HeapDumpOnOutOfMemoryError', '-XX:OnOutOfMemoryError=kill -9 %p']",
 ```
 
-* ``site.global.additional_node_properties`` and ``site.global.additional_config_properties`` (optional) (default - None): Presto launched via Slider will use ``config.properties`` and ``node.properties`` created from templates ``presto-yarn-package/package/templates/config.properties*.j2`` and ``presto-yarn-package/package/target/node.properties.j2`` respectively. If you want to add any additional properties to these configuration files, add ``site.global.additional_config_properties`` and ``site.global.additional_node_properties`` to your ``appConfig.json``. The value of these has to be a string with each property that has to go to the ``.properties`` file separated by a ``\n``. Eg:
+* ``site.global.additional_node_properties`` and ``site.global.additional_config_properties`` (optional) (default - None): Presto launched via Slider will use ``config.properties`` and ``node.properties`` created from templates ``presto-yarn-package/package/templates/config.properties*.j2`` and ``presto-yarn-package/package/target/node.properties.j2`` respectively. If you want to add any additional properties to these configuration files, add ``site.global.additional_config_properties`` and ``site.global.additional_node_properties`` to your ``appConfig.json``. The value of these has to be a string representation of an array of entries (key=value) that has to go to the ``.properties`` file. Eg:
 
 ```
-    "site.global.additional_config_properties": "task.max-worker-threads=5\ndistributed-joins-enabled=true"
+    "site.global.additional_config_properties": "['task.max-worker-threads=5', 'distributed-joins-enabled=true']"
 ```    
 
 * ``site.global.plugin`` (optional) (default - None): This allows you to add any additional jars you want to copy to plugin ``presto-server-<version>/plugin/<connector>`` directory in addition to what is already available there. It should be of the format {'connector1' : ['jar1', 'jar2'..], 'connector2' : ['jar3', 'jar4'..]..}. This will copy jar1, jar2 to Presto plugin directory at plugin/connector1 directory and jar3, jar4 at plugin/connector2 directory. Make sure you have the plugin jars you want to add to Presto available at ```presto-yarn-package/src/main/slider/package/plugins/``` prior to building the presto-yarn app package and thus the app package built ``presto-yarn-package-<version>-<presto-version>.zip`` will have the jars under ```package/plugins``` directory.
@@ -259,7 +259,7 @@ hdfs dfs -chown yarn:yarn /user/yarn
 
 * Make sure the data directory in the UI (added in ``appConfig-default.json`` eg: ``/var/lib/presto/``) is pre-created on all nodes and the directory must owned by user ``yarn``, otherwise slider will fail to start Presto with permission errors.
 
-* If you want to add any additional Custom properties, use Custom property section. Additional properties supported as of now is ``global.plugin``. See [section](#packageconfig) above for requirements and format of these properties.
+* If you want to add any additional Custom properties, use Custom property section. Additional properties supported as of now are ``site.global.plugin``, ``site.global.additional_config_properties`` and ``site.global.additional_node_properties``. See [section](#packageconfig) above for requirements and format of these properties.
 
 * Click Finish. This will basically do the equivalent of ```package  --install``` and ```create``` you do via the bin/slider script. Once successfully deployed, you will see the Yarn application started for Presto.
 

--- a/presto-yarn-package/src/main/resources/appConfig-test.json
+++ b/presto-yarn-package/src/main/resources/appConfig-test.json
@@ -17,7 +17,7 @@
     "site.global.catalog": "{'hive': ['connector.name=hive-cdh5', 'hive.metastore.uri=thrift://${NN_HOST}:9083'], 'tpch': ['connector.name=tpch'], 'jmx': ['connector.name=jmx']}",
     "site.global.jvm_args": "['-server', '-Xmx1024M', '-XX:+UseG1GC', '-XX:G1HeapRegionSize=32M', '-XX:+UseGCOverheadLimit', '-XX:+ExplicitGCInvokesConcurrent', '-XX:+HeapDumpOnOutOfMemoryError', '-XX:OnOutOfMemoryError=kill -9 %p', '-DHADOOP_USER_NAME=hdfs', '-Duser.timezone=UTC']",
 
-    "site.global.additional_node_properties": "plugin.config-dir=${AGENT_WORK_ROOT}/app/install/${dep.pkg.basename}/etc/catalog\nplugin.dir=${AGENT_WORK_ROOT}/app/install/${dep.pkg.basename}/plugin",
+    "site.global.additional_node_properties": "['plugin.config-dir=${AGENT_WORK_ROOT}/app/install/${dep.pkg.basename}/etc/catalog', 'plugin.dir=${AGENT_WORK_ROOT}/app/install/${dep.pkg.basename}/plugin']",
 
     "site.global.plugin": "{'ml': ['presto-ml-${presto.version}.jar']}",
 

--- a/presto-yarn-package/src/main/slider/package/scripts/configure.py
+++ b/presto-yarn-package/src/main/slider/package/scripts/configure.py
@@ -38,8 +38,13 @@ def set_configuration(component=None):
     
 
     if params.jvm_args:
-        jvm_arg_list = ast.literal_eval(params.jvm_args)
-        _store_configuration(jvm_arg_list, format("{params.conf_dir}/jvm.config"))
+        _parse_array_and_write(params.jvm_args, format("{params.conf_dir}/jvm.config"))
+
+    if params.additional_config_properties:        
+        _parse_array_and_write(params.additional_config_properties, format("{params.conf_dir}/config.properties"))
+
+    if params.additional_node_properties:
+        _parse_array_and_write(params.additional_node_properties, format("{params.conf_dir}/node.properties"))
 
     if params.catalog_properties:
         catalog_dict = ast.literal_eval(params.catalog_properties)
@@ -56,6 +61,10 @@ def set_configuration(component=None):
                 shutil.copy2(os.path.join(params.source_plugin_dir, jar), plugin_dir)
 
 
+def _parse_array_and_write(params_array, path):
+    arg_list = ast.literal_eval(params_array)
+    _store_configuration(arg_list, path)
+            
 def _store_configuration(parameters, path):
     with open(path, 'a') as fw:
         for parameter in parameters:

--- a/presto-yarn-package/src/main/slider/package/templates/config.properties-COORDINATOR.j2
+++ b/presto-yarn-package/src/main/slider/package/templates/config.properties-COORDINATOR.j2
@@ -5,4 +5,3 @@ http-server.http.port={{presto_server_port}}
 query.max-memory={{presto_query_max_memory}}
 query.max-memory-per-node={{presto_query_max_memory_per_node}}
 discovery.uri=http://localhost:{{presto_server_port}}
-{{additional_config_properties}}

--- a/presto-yarn-package/src/main/slider/package/templates/config.properties-WORKER.j2
+++ b/presto-yarn-package/src/main/slider/package/templates/config.properties-WORKER.j2
@@ -3,4 +3,3 @@ http-server.http.port={{presto_server_port}}
 query.max-memory={{presto_query_max_memory}}
 query.max-memory-per-node={{presto_query_max_memory_per_node}}
 discovery.uri=http://{{coordinator_host}}:{{presto_server_port}}
-{{additional_config_properties}}

--- a/presto-yarn-package/src/main/slider/package/templates/node.properties.j2
+++ b/presto-yarn-package/src/main/slider/package/templates/node.properties.j2
@@ -1,4 +1,3 @@
 node.environment=test
 node.id={{node_id}}
 node.data-dir={{data_dir}}
-{{additional_node_properties}}


### PR DESCRIPTION
Ambari Slider view couldnt recognize \n in the string value for
additional_config/node_properties. So make it an array like jvm_args.

SWARM-1855/ Issue #34
