### PR TITLE
Update default values to be more reasonable

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ Follow the steps here and configure the presto-yarn configuration files to match
 
 * ``site.global.singlenode`` (default - ``true``): If set to true, the node used act as both coordinator and worker (singlenode mode). For multi-node set up, this should be set to false.
 
-* ``site.global.presto_query_max_memory`` (default - ``5GB``): This will be used as ``query.max-memory`` in Presto's config.properties file.
+* ``site.global.presto_query_max_memory`` (default - ``50GB``): This will be used as ``query.max-memory`` in Presto's config.properties file.
 
-* ``site.global.presto_query_max_memory_per_node`` (default - ``600MB``):  This will be used as ``query.max-memory-per-node`` in Presto's config.properties file.
+* ``site.global.presto_query_max_memory_per_node`` (default - ``1GB``):  This will be used as ``query.max-memory-per-node`` in Presto's config.properties file.
 
 * ``site.global.presto_server_port`` (default - ``8080``): Presto server's http port.
 

--- a/presto-yarn-package/src/main/resources/appConfig.json
+++ b/presto-yarn-package/src/main/resources/appConfig.json
@@ -10,8 +10,8 @@
     "site.global.app_pkg_plugin": "${AGENT_WORK_ROOT}/app/definition/package/plugins/",
     "site.global.singlenode": "true",
     "site.global.coordinator_host": "${COORDINATOR_HOST}",
-    "site.global.presto_query_max_memory": "5GB",
-    "site.global.presto_query_max_memory_per_node": "600MB",
+    "site.global.presto_query_max_memory": "50GB",
+    "site.global.presto_query_max_memory_per_node": "1GB",
     "site.global.presto_server_port": "8080",
 
     "site.global.catalog": "{'tpch': ['connector.name=tpch']}",

--- a/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/PrestoClusterTest.groovy
+++ b/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/PrestoClusterTest.groovy
@@ -43,7 +43,6 @@ import static org.assertj.core.data.Offset.offset
 class PrestoClusterTest
         extends ProductTest
 {
-  private static final String APP_CONFIG_TEMPLATE = 'appConfig.json'
   private static final String APP_CONFIG_WITHOUT_CATALOG_TEMPLATE = 'appConfig-test-no-catalog.json'
   private static final String APP_CONFIG_TEST_TEMPLATE = 'appConfig-test.json'
 
@@ -163,7 +162,7 @@ class PrestoClusterTest
   @Test
   void 'limit single node failures'()
   {
-    PrestoCluster prestoCluster = new PrestoCluster(slider, hdfsClient, 'resources-singlenode-label.json', APP_CONFIG_TEMPLATE)
+    PrestoCluster prestoCluster = new PrestoCluster(slider, hdfsClient, 'resources-singlenode-label.json', APP_CONFIG_TEST_TEMPLATE)
     prestoCluster.withPrestoCluster {
       prestoCluster.assertThatPrestoIsUpAndRunning(0)
 
@@ -191,7 +190,7 @@ class PrestoClusterTest
   @Test
   void 'multi node with placement lifecycle'()
   {
-    PrestoCluster prestoCluster = new PrestoCluster(slider, hdfsClient, 'resources-multinode.json', APP_CONFIG_TEMPLATE)
+    PrestoCluster prestoCluster = new PrestoCluster(slider, hdfsClient, 'resources-multinode.json', APP_CONFIG_TEST_TEMPLATE)
     prestoCluster.withPrestoCluster {
       prestoCluster.assertThatPrestoIsUpAndRunning(workersCount())
 
@@ -262,7 +261,7 @@ class PrestoClusterTest
   @Test
   void 'labeling subset of nodes - single cordinatoor@master'()
   {
-    PrestoCluster prestoCluster = new PrestoCluster(slider, hdfsClient, 'resources-single-coordinator@master.json', APP_CONFIG_TEMPLATE)
+    PrestoCluster prestoCluster = new PrestoCluster(slider, hdfsClient, 'resources-single-coordinator@master.json', APP_CONFIG_TEST_TEMPLATE)
     prestoCluster.withPrestoCluster {
       prestoCluster.assertThatPrestoIsUpAndRunning(0)
 
@@ -275,7 +274,7 @@ class PrestoClusterTest
   @Test
   void 'flex set of workers - multinode-flex-worker'()
   {
-    PrestoCluster prestoCluster = new PrestoCluster(slider, hdfsClient, 'resources-multinode-single-worker.json', APP_CONFIG_TEMPLATE)
+    PrestoCluster prestoCluster = new PrestoCluster(slider, hdfsClient, 'resources-multinode-single-worker.json', APP_CONFIG_TEST_TEMPLATE)
     prestoCluster.withPrestoCluster {
       prestoCluster.assertThatPrestoIsUpAndRunning(1)
       assertThatAllProcessesAreRunning(prestoCluster)


### PR DESCRIPTION
Update default memory settings to be more reasonable and to match Presto
docs. The settings were set to low for using it for product tests. We
have a separate config for testing, so just use that instead of the
default one.

SWARM-1899
