### PR TITLE
Deploy Presto configuration files to a static location

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Follow the steps here and configure the presto-yarn configuration files to match
 
 * ``site.global.data_dir`` (default - ``/var/lib/presto/data``): The data directory configured should be pre-created on all nodes and must be owned by user ``yarn``, otherwise slider will fail to start Presto with permission errors.
 
+* ``site.global.config_dir`` (default - ``/var/lib/presto/etc``): The configuration directory on the cluster where the Presto config files node.properties, jvm.config, config.properties and connector configuration files are deployed. These files will have configuration values created from templates ``presto-yarn-package/package/templates/*.j2`` and other relevant ``appConfig.json`` parameters.
+
 * ``site.global.singlenode`` (default - ``true``): If set to true, the node used act as both coordinator and worker (singlenode mode). For multi-node set up, this should be set to false.
 
 * ``site.global.presto_query_max_memory`` (default - ``50GB``): This will be used as ``query.max-memory`` in Presto's config.properties file.
@@ -258,7 +260,7 @@ hdfs dfs -chown yarn:yarn /user/yarn
 
 * Make sure you change the ``global.presto_server_port`` from 8080 to some other unused port, since Ambari by default uses 8080.
 
-* Make sure the data directory in the UI (added in ``appConfig-default.json`` eg: ``/var/lib/presto/``) is pre-created on all nodes and the directory must owned by user ``yarn``, otherwise slider will fail to start Presto with permission errors.
+* Make sure the data directory in the UI (added in ``appConfig-default.json`` eg: ``/var/lib/presto/``) is pre-created on all nodes and the directory must owned by ``global.app_user``, otherwise slider will fail to start Presto with permission errors.
 
 * If you want to add any additional Custom properties, use Custom property section. Additional properties supported as of now are ``site.global.plugin``, ``site.global.additional_config_properties`` and ``site.global.additional_node_properties``. See [section](#packageconfig) above for requirements and format of these properties.
 
@@ -394,6 +396,7 @@ See http://slider.incubator.apache.org/docs/configuration/resources.html#logagg 
 
 * Presto logs will be available under the standard Presto data directory location. By default it is ``/var/lib/presto/data/var/log`` directory where ``/var/lib/presto/data`` is the default data directory configured in Slider ``appConfig.json``. You can find both ``server.log`` and ``http-request.log`` files here. Please note that log rotation of these Presto log files will have to be manually enabled (for eg: using http://linuxcommand.org/man_pages/logrotate8.html)
 
+* Presto configuration files will be at ``/var/lib/presto/etc`` directory if you are using the default ``appConfig.json`` property ``site.global.config_dir``.  
 
 # Links
 

--- a/README.md
+++ b/README.md
@@ -396,11 +396,7 @@ See http://slider.incubator.apache.org/docs/configuration/resources.html#logagg 
 
 * Presto logs will be available under the standard Presto data directory location. By default it is ``/var/lib/presto/data/var/log`` directory where ``/var/lib/presto/data`` is the default data directory configured in Slider ``appConfig.json``. You can find both ``server.log`` and ``http-request.log`` files here. Please note that log rotation of these Presto log files will have to be manually enabled (for eg: using http://linuxcommand.org/man_pages/logrotate8.html)
 
-<<<<<<< HEAD
-* Presto configuration files will be at ``/var/lib/presto/etc`` directory if you are using the default ``appConfig.json`` property ``site.global.config_dir``.  
-=======
 * Presto configuration files will be at ``/var/lib/presto/etc`` directory if you are using the default ``appConfig.json`` property ``site.global.config_dir``.
->>>>>>> Deploy Presto configuration files to a static location
 
 # Links
 

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ hdfs dfs -chown yarn:yarn /user/yarn
 
 * Make sure you change the ``global.presto_server_port`` from 8080 to some other unused port, since Ambari by default uses 8080.
 
-* Make sure the data directory in the UI (added in ``appConfig-default.json`` eg: ``/var/lib/presto/``) is pre-created on all nodes and the directory must owned by ``global.app_user``, otherwise slider will fail to start Presto with permission errors.
+* Make sure the data directory in the UI (added in ``appConfig-default.json`` eg: ``/var/lib/presto/``) is pre-created on all nodes and the directory must be owned by ``global.app_user``, otherwise slider will fail to start Presto with permission errors.
 
 * If you want to add any additional Custom properties, use Custom property section. Additional properties supported as of now are ``site.global.plugin``, ``site.global.additional_config_properties`` and ``site.global.additional_node_properties``. See [section](#packageconfig) above for requirements and format of these properties.
 
@@ -396,7 +396,11 @@ See http://slider.incubator.apache.org/docs/configuration/resources.html#logagg 
 
 * Presto logs will be available under the standard Presto data directory location. By default it is ``/var/lib/presto/data/var/log`` directory where ``/var/lib/presto/data`` is the default data directory configured in Slider ``appConfig.json``. You can find both ``server.log`` and ``http-request.log`` files here. Please note that log rotation of these Presto log files will have to be manually enabled (for eg: using http://linuxcommand.org/man_pages/logrotate8.html)
 
+<<<<<<< HEAD
 * Presto configuration files will be at ``/var/lib/presto/etc`` directory if you are using the default ``appConfig.json`` property ``site.global.config_dir``.  
+=======
+* Presto configuration files will be at ``/var/lib/presto/etc`` directory if you are using the default ``appConfig.json`` property ``site.global.config_dir``.
+>>>>>>> Deploy Presto configuration files to a static location
 
 # Links
 

--- a/presto-yarn-package/src/main/resources/appConfig-test.json
+++ b/presto-yarn-package/src/main/resources/appConfig-test.json
@@ -6,6 +6,7 @@
     "site.global.app_user": "yarn",
     "site.global.user_group": "hadoop",
     "site.global.data_dir": "/var/lib/presto/data",
+    "site.global.config_dir": "/var/lib/presto/etc",
     "site.global.app_name": "${dep.pkg.basename}",
     "site.global.app_pkg_plugin": "${AGENT_WORK_ROOT}/app/definition/package/plugins/",
     "site.global.singlenode": "true",
@@ -17,7 +18,7 @@
     "site.global.catalog": "{'hive': ['connector.name=hive-cdh5', 'hive.metastore.uri=thrift://${NN_HOST}:9083'], 'tpch': ['connector.name=tpch'], 'jmx': ['connector.name=jmx']}",
     "site.global.jvm_args": "['-server', '-Xmx1024M', '-XX:+UseG1GC', '-XX:G1HeapRegionSize=32M', '-XX:+UseGCOverheadLimit', '-XX:+ExplicitGCInvokesConcurrent', '-XX:+HeapDumpOnOutOfMemoryError', '-XX:OnOutOfMemoryError=kill -9 %p', '-DHADOOP_USER_NAME=hdfs', '-Duser.timezone=UTC']",
 
-    "site.global.additional_node_properties": "['plugin.config-dir=${AGENT_WORK_ROOT}/app/install/${dep.pkg.basename}/etc/catalog', 'plugin.dir=${AGENT_WORK_ROOT}/app/install/${dep.pkg.basename}/plugin']",
+    "site.global.additional_node_properties": "['plugin.dir=${AGENT_WORK_ROOT}/app/install/${dep.pkg.basename}/plugin']",
 
     "site.global.plugin": "{'ml': ['presto-ml-${presto.version}.jar']}",
 

--- a/presto-yarn-package/src/main/resources/appConfig.json
+++ b/presto-yarn-package/src/main/resources/appConfig.json
@@ -6,6 +6,7 @@
     "site.global.app_user": "yarn",
     "site.global.user_group": "hadoop",
     "site.global.data_dir": "/var/lib/presto/data",
+    "site.global.config_dir": "/var/lib/presto/etc",
     "site.global.app_name": "${dep.pkg.basename}",
     "site.global.app_pkg_plugin": "${AGENT_WORK_ROOT}/app/definition/package/plugins/",
     "site.global.singlenode": "true",

--- a/presto-yarn-package/src/main/slider/package/scripts/configure.py
+++ b/presto-yarn-package/src/main/slider/package/scripts/configure.py
@@ -28,6 +28,9 @@ def set_configuration(component=None):
     """
     import params
 
+    if (os.path.exists(format("{conf_dir}"))):
+        shutil.rmtree(format("{conf_dir}"))
+                      
     _directory(params.conf_dir, params)
     _directory(params.catalog_dir, params)
     _directory(params.pid_dir, params)

--- a/presto-yarn-package/src/main/slider/package/scripts/params.py
+++ b/presto-yarn-package/src/main/slider/package/scripts/params.py
@@ -30,7 +30,8 @@ app_root = config['configurations']['global']['app_root']
 app_name = config['configurations']['global']['app_name']
 
 presto_root = format("{app_root}/{app_name}")
-conf_dir = format("{presto_root}/etc")
+conf_dir = default('/configurations/global/config_dir', format("{presto_root}/etc"))
+
 catalog_dir = format("{conf_dir}/catalog")
 presto_plugin_dir = format("{presto_root}/plugin")
 source_plugin_dir = config['configurations']['global']['app_pkg_plugin']

--- a/presto-yarn-package/src/main/slider/package/scripts/presto_server.py
+++ b/presto-yarn-package/src/main/slider/package/scripts/presto_server.py
@@ -39,7 +39,7 @@ class PrestoServer(Script):
         env.set_params(params)
 
         self.configure()
-        process_cmd = format("PATH={java8_home}/bin:$PATH {presto_root}/bin/launcher run >> {log_file} 2>&1")
+        process_cmd = format("PATH={java8_home}/bin:$PATH {presto_root}/bin/launcher run --node-config {conf_dir}/node.properties --jvm-config {conf_dir}/jvm.config --config {conf_dir}/config.properties >> {log_file} 2>&1")
 
         Execute(process_cmd,
                 logoutput=True,

--- a/presto-yarn-package/src/main/slider/package/templates/config.properties-COORDINATOR.j2
+++ b/presto-yarn-package/src/main/slider/package/templates/config.properties-COORDINATOR.j2
@@ -4,5 +4,5 @@ discovery-server.enabled=true
 http-server.http.port={{presto_server_port}}
 query.max-memory={{presto_query_max_memory}}
 query.max-memory-per-node={{presto_query_max_memory_per_node}}
-query.queue-config-file=etc/queues.json
+query.queue-config-file={{conf_dir}}/queues.json
 discovery.uri=http://{{coordinator_host}}:{{presto_server_port}}

--- a/presto-yarn-package/src/main/slider/package/templates/node.properties.j2
+++ b/presto-yarn-package/src/main/slider/package/templates/node.properties.j2
@@ -1,3 +1,4 @@
 node.environment=test
 node.id={{node_id}}
 node.data-dir={{data_dir}}
+plugin.config-dir={{catalog_dir}}

--- a/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/PrestoClusterTest.groovy
+++ b/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/PrestoClusterTest.groovy
@@ -48,8 +48,7 @@ class PrestoClusterTest
 
   private static final String JVM_HEAPSIZE = "1024.0MB"
   private static final String JVM_ARGS = "-DHADOOP_USER_NAME=hdfs -Duser.timezone=UTC"
-  private static final String ADDITIONAL_NODE_PROPERTY1 = "-Dplugin.config-dir="
-  private static final String ADDITIONAL_NODE_PROPERTY2 = "-Dplugin.dir="
+  private static final String ADDITIONAL_NODE_PROPERTY = "-Dplugin.dir="
   
   private static final long TIMEOUT = MINUTES.toMillis(4)
 
@@ -317,8 +316,7 @@ class PrestoClusterTest
     String coordinatorHost = prestoCluster.coordinatorHost
     def prestoProcess = nodeSshUtils.getPrestoJvmProcess(coordinatorHost)
 
-    assertThat(prestoProcess).contains(ADDITIONAL_NODE_PROPERTY1)
-    assertThat(prestoProcess).contains(ADDITIONAL_NODE_PROPERTY2)
+    assertThat(prestoProcess).contains(ADDITIONAL_NODE_PROPERTY)
   }
   
   private void assertThatJvmArgsAreCorrect(PrestoCluster prestoCluster)

--- a/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/slider/Slider.groovy
+++ b/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/slider/Slider.groovy
@@ -87,13 +87,13 @@ class Slider
   private Path uploadIfNeeded(Path clusterPackage)
   {
     def packageName = clusterPackage.fileName
-/*    if (checkMd5OfUploadedFile(clusterPackage)) {
+    if (checkMd5OfUploadedFile(clusterPackage)) {
       log.info("Package ${packageName} is already uploaded. Md5sum checksums match.")
     }
     else {
       upload(clusterPackage)
       checkState(checkMd5OfUploadedFile(clusterPackage), "Uploaded file is corrupted, please try again")
-    }*/
+    }
     return packageName
   }
 

--- a/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/slider/Slider.groovy
+++ b/presto-yarn-test/src/test/groovy/com/teradata/presto/yarn/slider/Slider.groovy
@@ -87,13 +87,13 @@ class Slider
   private Path uploadIfNeeded(Path clusterPackage)
   {
     def packageName = clusterPackage.fileName
-    if (checkMd5OfUploadedFile(clusterPackage)) {
+/*    if (checkMd5OfUploadedFile(clusterPackage)) {
       log.info("Package ${packageName} is already uploaded. Md5sum checksums match.")
     }
     else {
       upload(clusterPackage)
       checkState(checkMd5OfUploadedFile(clusterPackage), "Uploaded file is corrupted, please try again")
-    }
+    }*/
     return packageName
   }
 


### PR DESCRIPTION
We do not want the configuration files to disapper during YARN app stop.
Save it in the data directory instead of deploying it within the
container directory (which is deleted when YARN app stops)

Testing: product tests, Ambari Slider
