### PR TITLE
Export Presto coordinator host:port from slider

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,16 @@ If you want to check the status of running application you run the following, an
 bin/slider status presto1 --out status_file
 ```
 
+##### Check where the coordinator is running
+
+Use the following command to check what is the host and port of presto coordinator after deployment, so that you can connect to it. You can use output of this command to specify --server flag on presto command line. 
+
+```
+bin/slider registry --name presto1 --getexp presto
+```
+
+You can also view this information through Slider REST API and YARN Application UI. 
+
 ##### Destroy the app and re-create
 
 If you want to re-create the app due to some failures or you want to reconfigure Presto (eg: add a new connector)

--- a/presto-yarn-package/src/main/slider/metainfo.xml
+++ b/presto-yarn-package/src/main/slider/metainfo.xml
@@ -28,7 +28,7 @@
           <name>Presto</name>
           <exports>
             <export>
-              <name>coordinator_host</name>
+              <name>coordinator_address</name>
               <value>${COORDINATOR_HOST}:${site.global.presto_server_port}</value>
             </export>
           </exports>
@@ -39,7 +39,7 @@
           <component>
               <name>COORDINATOR</name>
               <category>MASTER</category>
-              <appExports>Presto-coordinator_host</appExports>
+              <appExports>Presto-coordinator_address</appExports>
               <minInstanceCount>1</minInstanceCount>
               <maxInstanceCount>1</maxInstanceCount>
               <commandScript>

--- a/presto-yarn-package/src/main/slider/metainfo.xml
+++ b/presto-yarn-package/src/main/slider/metainfo.xml
@@ -23,10 +23,23 @@
     <comment>Presto DB</comment>
     <version>${presto.version}</version>
 
+       <exportGroups>
+        <exportGroup>
+          <name>Presto</name>
+          <exports>
+            <export>
+              <name>coordinator_host</name>
+              <value>${COORDINATOR_HOST}:${site.global.presto_server_port}</value>
+            </export>
+          </exports>
+        </exportGroup>
+      </exportGroups>
+     
       <components>
           <component>
               <name>COORDINATOR</name>
               <category>MASTER</category>
+              <appExports>Presto-coordinator_host</appExports>
               <minInstanceCount>1</minInstanceCount>
               <maxInstanceCount>1</maxInstanceCount>
               <commandScript>


### PR DESCRIPTION
Exporting coordinator host:port from slider allows the tools to know where to connect to. The exported info can be accessed via REST API or through command line:
e.g. slider registry  --name presto1 --getexp presto

More info on Slider export : http://slider.incubator.apache.org/docs/slider_specs/specifying_exports.html