### PR TITLE
Upgrade Presto to 0.167 and update the hive connector name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     </modules>
 
     <properties>
-        <presto.version>0.157.1</presto.version>
+        <presto.version>0.167</presto.version>
         <slider.version>0.80.0-incubating</slider.version>
         <junit.version>4.11</junit.version>
         <tempto.version>1.4</tempto.version>

--- a/presto-yarn-docs/src/main/sphinx/installation-yarn-configuration-options.rst
+++ b/presto-yarn-docs/src/main/sphinx/installation-yarn-configuration-options.rst
@@ -115,7 +115,7 @@ scripts(bin/slider) as user ``hdfs`` in this case.
 
 ::
 
-        "site.global.catalog": "{'hive': ['connector.name=hive-cdh5', 'hive.metastore.uri=thrift://${NN_HOST}:9083'], 'tpch': ['connector.name=tpch']}"
+        "site.global.catalog": "{'hive': ['connector.name=hive-hadoop2', 'hive.metastore.uri=thrift://${NN_HOST}:9083'], 'tpch': ['connector.name=tpch']}"
 
 ``Note``: The ``NN_HOST`` used in ``hive.metastore.uri`` is a variable
 for your HDFS Namenode and this expects that your hive metastore is up

--- a/presto-yarn-package/src/main/resources/appConfig-test.json
+++ b/presto-yarn-package/src/main/resources/appConfig-test.json
@@ -15,7 +15,7 @@
     "site.global.presto_query_max_memory_per_node": "600MB",
     "site.global.presto_server_port": "8080",
     
-    "site.global.catalog": "{'hive': ['connector.name=hive-cdh5', 'hive.metastore.uri=thrift://${NN_HOST}:9083'], 'tpch': ['connector.name=tpch'], 'jmx': ['connector.name=jmx']}",
+    "site.global.catalog": "{'hive': ['connector.name=hive-hadoop2', 'hive.metastore.uri=thrift://${NN_HOST}:9083'], 'tpch': ['connector.name=tpch'], 'jmx': ['connector.name=jmx']}",
     "site.global.jvm_args": "['-server', '-Xmx1024M', '-XX:+UseG1GC', '-XX:G1HeapRegionSize=32M', '-XX:+UseGCOverheadLimit', '-XX:+ExplicitGCInvokesConcurrent', '-XX:+HeapDumpOnOutOfMemoryError', '-XX:OnOutOfMemoryError=kill -9 %p', '-DHADOOP_USER_NAME=hdfs', '-Duser.timezone=UTC']",
     "site.global.log_properties": "['com.facebook.presto=INFO']",
 

--- a/presto-yarn-test/src/test/resources/status_file
+++ b/presto-yarn-test/src/test/resources/status_file
@@ -30,7 +30,7 @@
     "site.global.additional_node_properties" : "['plugin.dir=${AGENT_WORK_ROOT}/app/install/presto-server-0.130/plugin']",
     "yarn.vcores" : "1",
     "site.global.security_enabled" : "false",
-    "site.global.catalog" : "{'hive': ['connector.name=hive-cdh5', 'hive.metastore.uri=thrift://${NN_HOST}:9083'], 'tpch': ['connector.name=tpch'], 'jmx': ['connector.name=jmx']}",
+    "site.global.catalog" : "{'hive': ['connector.name=hive-hadoop2', 'hive.metastore.uri=thrift://${NN_HOST}:9083'], 'tpch': ['connector.name=tpch'], 'jmx': ['connector.name=jmx']}",
     "java_home" : "/usr/lib/jvm/java",
     "zookeeper.quorum" : "master:5181",
     "slider.cluster.directory.permissions" : "0770",


### PR DESCRIPTION
With Presto 0.167 it longer supports hive-cdh5 connector name. Update it to use hive-hadoop2 instead