### PR TITLE
Add event listener config support

### DIFF
--- a/presto-yarn-docs/src/main/sphinx/installation-yarn-configuration-options.rst
+++ b/presto-yarn-docs/src/main/sphinx/installation-yarn-configuration-options.rst
@@ -208,7 +208,17 @@ hostname.
     ``${AGENT_WORK_ROOT}`` etc. do not need any substitution and will be
     appropriately configured during runtime.
     
- .. _resources-json-label:
+
+18. ``site.global.event_listener_properties``: This allows you to configure Presto `Event Listener <https://prestodb.io/docs/current/develop/event-listener.html>`_. By default there is no listener configured. Since, presto needs ``event-listener.properties`` file to be a list of options, one per line, this property must be a String representation of list of strings. Each entry of this list will be a new line in your ``event-listener.properties``. For example,
+    below configuration will add the event listener named ``custom-event-listener`` with two custom properties ``custom-property1`` and ``custom-property2``.
+    
+::
+
+   "site.global.event_listener_properties": "['event-listener.name=custom-event-listener',
+   'custom-property1=custom-value1','custom-property2=custom-value2']" 
+
+
+.. _resources-json-label:
 
 resources.json
 ~~~~~~~~~~~~~~

--- a/presto-yarn-package/src/main/slider/package/scripts/configure.py
+++ b/presto-yarn-package/src/main/slider/package/scripts/configure.py
@@ -49,7 +49,10 @@ def set_configuration(component=None):
 
     if params.log_properties:
         _parse_array_and_write(params.log_properties, format("{params.conf_dir}/log.properties"))
-
+ 
+    if params.event_listener_properties:
+        _parse_array_and_write(params.event_listener_properties, format("{params.conf_dir}/event-listener.properties"))
+        
     if params.additional_config_properties:        
         _parse_array_and_write(params.additional_config_properties, format("{params.conf_dir}/config.properties"))
 

--- a/presto-yarn-package/src/main/slider/package/scripts/params.py
+++ b/presto-yarn-package/src/main/slider/package/scripts/params.py
@@ -53,6 +53,7 @@ presto_query_max_memory_per_node = config['configurations']['global']['presto_qu
 presto_server_port = config['configurations']['global']['presto_server_port']
 jvm_args = default('/configurations/global/jvm_args', '')
 log_properties = default('/configurations/global/log_properties', '')
+event_listener_properties = default('/configurations/global/event_listener_properties', '')
 
 node_id = uuid.uuid1()
 


### PR DESCRIPTION
This PR adds support for Presto Event listener to be configured with presto yarn. More details about presto event listener can be found here : https://prestodb.io/docs/current/develop/event-listener.html
 